### PR TITLE
Uninstall deps

### DIFF
--- a/localrepo/config.py
+++ b/localrepo/config.py
@@ -29,7 +29,8 @@ class Config:
 	         'pkgbuild': str,
 	         'sign': bool,
 	         'signdb': bool,
-	         'no-aur-upgrade': list}
+	         'no-aur-upgrade': list,
+	         'uninstall_deps': bool}
 
 	#: The ConfigParser instance
 	_parser = ConfigParser()

--- a/localrepo/localrepo.py
+++ b/localrepo/localrepo.py
@@ -113,6 +113,17 @@ class LocalRepo:
 			LocalRepo.error(e)
 
 	@staticmethod
+	def _uninstall_deps(names):
+		''' Uninstalls previoulsy installed dependencies '''
+		Msg.info(_('Installed following packages as dependencies:\n[{0}]').format(', '.join(names)))
+
+		if Msg.ask(_('Uninstall?')):
+			try:
+				Pacman.uninstall(names)
+			except LocalRepoError as e:
+				LocalRepo.error(e)
+
+	@staticmethod
 	def _make_package(path):
 		''' Makes a new package '''
 		Msg.process(_('Forging a new package: {0}').format(path))
@@ -124,9 +135,15 @@ class LocalRepo:
 			LocalRepo._install_deps(e.deps)
 
 			try:
-				return Package.from_pkgbuild(e.pkgbuild, ignore_deps=True)
+				pkg = Package.from_pkgbuild(e.pkgbuild, ignore_deps=True)
 			except LocalRepoError as e:
 				LocalRepo.error(e)
+
+			if Config.get('uninstall_deps', True):
+				LocalRepo._uninstall_deps(e.deps)
+
+			return pkg
+			
 		except LocalRepoError as e:
 			LocalRepo.error(e)
 

--- a/localrepo/pacman.py
+++ b/localrepo/pacman.py
@@ -70,6 +70,20 @@ class Pacman:
 		Pacman.call(cmd)
 
 	@staticmethod
+	def uninstall(pkgs):
+		''' Unnstalls packages '''
+		cmd = [Pacman.PACMAN, '-R'] + pkgs
+
+		if getuid() is not 0:
+			if exists(Pacman.SUDO):
+				cmd.insert(0, Pacman.SUDO)
+			else:
+				cmd = [Pacman.SU, '-c', '\'{0}\''.format(' '.join(cmd))]
+
+		Pacman.call(cmd)
+
+
+	@staticmethod
 	def check_deps(pkgs):
 		''' Checks for unresolved dependencies '''
 		cmd = [Pacman.PACMAN, '-T'] + pkgs


### PR DESCRIPTION
I've added an option that, if enabled, uninstalls previously installed deps.
This is useful if vou have one machine where you have localrepo installed, but don't need everything on this system and thus you don't want to have all these unnecessary deps installed.
